### PR TITLE
Fix XDG_CONFIG_HOME in setup script

### DIFF
--- a/setup
+++ b/setup
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 bin="$HOME/.local/bin"
-config="$XDG_CONFIGHOME/fzfx"
+config="$XDG_CONFIG_HOME/fzfx"
 
 doInstall() {
     # Install binaries


### PR DESCRIPTION
This fixes the setup script using ``config="$XDG_CONFIGHOME/fzfx"``, which fails because ``$XDG_CONFIGHOME`` doesn't exist (it should be $XDG_CONFIG_HOME). Thanks!